### PR TITLE
Fix example: use timestamp instead whole object

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class MyKeyGenerator implements KeyGeneratorInterface
 {
     public function generateKey($value)
     {
-        return get_class($value) . '_' . $value->getId() . '_' . $value->getUpdatedAt();
+        return get_class($value) . '_' . $value->getId() . '_' . $value->getUpdatedAt()->getTimestamp();
     }
 
 }


### PR DESCRIPTION
Prevent object to string conversion error
