### PR TITLE
Remove call of Twig_Template::getEnvironment

### DIFF
--- a/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
+++ b/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
@@ -41,7 +41,7 @@ class CacheNode extends \Twig_Node
 
         $compiler
             ->addDebugInfo($this)
-            ->write("\$asm89CacheStrategy".$i." = \$this->getEnvironment()->getExtension('asm89_cache')->getCacheStrategy();\n")
+            ->write("\$asm89CacheStrategy".$i." = \$this->env->getExtension('asm89_cache')->getCacheStrategy();\n")
             ->write("\$asm89Key".$i." = \$asm89CacheStrategy".$i."->generateKey(")
                 ->subcompile($this->getNode('annotation'))
                 ->raw(", ")


### PR DESCRIPTION
It deprecated since 1.20 (to be removed in 2.0)