### PR TITLE
Added BlackholeCacheStrategy for dev/debug-Mode to avoid any caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ For example: entities containing a last update time, would include a timestamp
 in the key. For an interesting blog post about this type of caching see:
 http://37signals.com/svn/posts/3113-how-key-based-cache-expiration-works
 
+### Blackhole
+
+Strategy for debug/development mode. It generates always a new key, will never fetch a block and never save a block.  
+
 #### Setup
 
 In order to use the strategy you need to setup a `KeyGenerator` class that is

--- a/lib/Asm89/Twig/CacheExtension/CacheStrategy/BlackholeCacheStrategy.php
+++ b/lib/Asm89/Twig/CacheExtension/CacheStrategy/BlackholeCacheStrategy.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of twig-cache-extension.
  *
- * (c) Hagen Hübel <hhuebel@itinance.com>
+ * (c) Alexander <iam.asm89@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,9 +13,20 @@ namespace Asm89\Twig\CacheExtension\CacheStrategy;
 
 use Asm89\Twig\CacheExtension\CacheStrategyInterface;
 
+/**
+ * CacheStrategy which doesn't cache at all
+ *
+ * This strategy can be used in development mode, e.g. editing twig templates,
+ * to prevent previously cached versions from being rendered.
+ *
+ * @see     https://github.com/asm89/twig-cache-extension/pull/29
+ *
+ * @author  Hagen Hübel <hhuebel@itinance.com>
+ *
+ * @package Asm89\Twig\CacheExtension\CacheStrategy
+ */
 class BlackholeCacheStrategy implements CacheStrategyInterface
 {
-
     /**
      * {@inheritDoc}
      */

--- a/lib/Asm89/Twig/CacheExtension/CacheStrategy/BlackholeCacheStrategy.php
+++ b/lib/Asm89/Twig/CacheExtension/CacheStrategy/BlackholeCacheStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of twig-cache-extension.
+ *
+ * (c) Hagen Hübel <hhuebel@itinance.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Twig\CacheExtension\CacheStrategy;
+
+use Asm89\Twig\CacheExtension\CacheStrategyInterface;
+
+class BlackholeCacheStrategy implements CacheStrategyInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchBlock($key)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generateKey($annotation, $value)
+    {
+        return microtime(true) . mt_rand();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function saveBlock($key, $block)
+    {
+        // fire and forget
+    }
+}


### PR DESCRIPTION
In Development Mode it could be very annoying sometimes to have to clear the cache files at all when changing some twig and the previous cached version is rendered instead of the modified one.

With this new Strategy one can overwrite the twig_cache-settings in config_dev.yml to avoid any caching:
e.g.

**services.yml:**

```jinja
    twig.strategy.blackhole:
        class: Asm89\Twig\CacheExtension\CacheStrategy\BlackholeCacheStrategy
```

**config_dev.yml**

```jinja
twig_cache:
    strategy: twig.strategy.blackhole
```