### PR TITLE
Twig 2 compatibility

### DIFF
--- a/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
+++ b/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
@@ -27,7 +27,7 @@ class CacheNode extends \Twig_Node
      * @param integer               $lineno
      * @param string                $tag
      */
-    public function __construct(\Twig_Node_Expression $annotation, \Twig_Node_Expression $keyInfo, \Twig_NodeInterface $body, $lineno, $tag = null)
+    public function __construct(\Twig_Node_Expression $annotation, \Twig_Node_Expression $keyInfo, \Twig_Node $body, $lineno, $tag = null)
     {
         parent::__construct(array('key_info' => $keyInfo, 'body' => $body, 'annotation' => $annotation), array(), $lineno, $tag);
     }


### PR DESCRIPTION
The `Twig_NodeInterface` interface is deprecated in Twig 1.x and will be
removed in Twig 2. Changing `Twig_NodeInterface` to `Twig_Node` should
make the extension ready to support both Twig 1 and Twig 2 for now.