### PR TITLE
Add PSR-6 compatible adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,33 @@ $cacheExtension = new CacheExtension($cacheStrategy);
 $twig->addExtension($cacheExtension);
 ```
 
+### Want to use a PSR-6 cache pool?
+
+Instead of using the default `DoctrineCacheAdapter` the extension also has 
+a `PSR-6` compatible adapter. You need to instantiate one of the cache pool
+implementations as can be found on: http://php-cache.readthedocs.io/en/latest/
+
+Example: Making use of the `ApcuCachePool` via the `PsrCacheAdapter`:
+
+```bash
+composer require cache/apcu-adapter
+```
+
+```php
+<?php
+
+use Asm89\Twig\CacheExtension\CacheProvider\PsrCacheAdapter;
+use Asm89\Twig\CacheExtension\CacheStrategy\LifetimeCacheStrategy;
+use Asm89\Twig\CacheExtension\Extension as CacheExtension;
+use Cache\Adapter\Apcu\ApcuCachePool();
+
+$cacheProvider  = new PsrCacheAdapter(new ApcuCachePool());
+$cacheStrategy  = new LifetimeCacheStrategy($cacheProvider);
+$cacheExtension = new CacheExtension($cacheStrategy);
+
+$twig->addExtension($cacheExtension);
+```
+
 ### Usage
 
 To cache a part of a template in Twig surround the code with a `cache` block.

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "require-dev": {
         "doctrine/cache": "~1.0"
     },
+    "suggest": {
+        "psr/cache-implementation": "To make use of PSR-6 cache implementation via PsrCacheAdapter."
+    },
     "autoload": {
         "psr-4": {
             "": "lib/"

--- a/lib/Asm89/Twig/CacheExtension/CacheProvider/PsrCacheAdapter.php
+++ b/lib/Asm89/Twig/CacheExtension/CacheProvider/PsrCacheAdapter.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of twig-cache-extension.
+ *
+ * (c) Alexander <iam.asm89@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Twig\CacheExtension\CacheProvider;
+
+use Asm89\Twig\CacheExtension\CacheProviderInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Adapter class to make extension interoperable with every PSR-6 adapter.
+ *
+ * @see http://php-cache.readthedocs.io/
+ *
+ * @author Rvanlaak <rvanlaak@gmail.com>
+ */
+class PsrCacheAdapter implements CacheProviderInterface
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param CacheItemPoolInterface $cache
+     */
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param string $key
+     * @return mixed|false
+     */
+    public function fetch($key)
+    {
+        // PSR-6 implementation returns null, CacheProviderInterface expects false
+        $item = $this->cache->getItem($key);
+        if ($item->isHit()) {
+            return $item->get();
+        }
+        return false;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @param int|\DateInterval $lifetime
+     * @return bool
+     */
+    public function save($key, $value, $lifetime = 0)
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($value);
+        $item->expiresAfter($lifetime);
+
+        return $this->cache->save($item);
+    }
+
+}


### PR DESCRIPTION
Next to the already available `DoctrineCacheAdapter` this PR adds a PSR-6 compatible adapter, which without any BC break allows to easily implement one of the pools available at:

http://php-cache.readthedocs.io/

In my opinion, and I think @Nyholm agrees with that too, it would be better to completely follow PSR-6 and get rid of all adapters, but that would be a huge BC break. I'd propose to release `1.3.0` after merging.