### PR TITLE
fix deprecation message. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 composer.lock
 composer.phar
 /vendor/
+.idea/

--- a/lib/Asm89/Twig/CacheExtension/Extension.php
+++ b/lib/Asm89/Twig/CacheExtension/Extension.php
@@ -41,6 +41,9 @@ class Extension extends \Twig_Extension
      */
     public function getName()
     {
+        if (version_compare(\Twig_Environment::VERSION, '1.26.0', '>=')) {
+            return get_class($this);
+        }
         return 'asm89_cache';
     }
 

--- a/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
+++ b/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
@@ -39,9 +39,15 @@ class CacheNode extends \Twig_Node
     {
         $i = self::$cacheCount++;
 
+        if (version_compare(\Twig_Environment::VERSION, '1.26.0', '>=')) {
+            $extension = 'Asm89\Twig\CacheExtension\Extension';
+        } else {
+            $extension = 'asm89_cache';
+        }
+
         $compiler
             ->addDebugInfo($this)
-            ->write("\$asm89CacheStrategy".$i." = \$this->env->getExtension('asm89_cache')->getCacheStrategy();\n")
+            ->write("\$asm89CacheStrategy".$i." = \$this->env->getExtension('{$extension}')->getCacheStrategy();\n")
             ->write("\$asm89Key".$i." = \$asm89CacheStrategy".$i."->generateKey(")
                 ->subcompile($this->getNode('annotation'))
                 ->raw(", ")


### PR DESCRIPTION
> Referencing the ... extension by its name (defined by getName()) is deprecated since 1.26 and will be removed in Twig 2.0. Use the Fully Qualified Extension Class Name instead