### PR TITLE
Referencing the "Asm89\Twig\CacheExtension\Extension" extension by it…

### DIFF
--- a/lib/Asm89/Twig/CacheExtension/Extension.php
+++ b/lib/Asm89/Twig/CacheExtension/Extension.php
@@ -41,7 +41,7 @@ class Extension extends \Twig_Extension
      */
     public function getName()
     {
-        return 'asm89_cache';
+        return Extension::class;
     }
 
     /**

--- a/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
+++ b/lib/Asm89/Twig/CacheExtension/Node/CacheNode.php
@@ -11,6 +11,8 @@
 
 namespace Asm89\Twig\CacheExtension\Node;
 
+use Asm89\Twig\CacheExtension\Extension;
+
 /**
  * Cache twig node.
  *
@@ -41,7 +43,7 @@ class CacheNode extends \Twig_Node
 
         $compiler
             ->addDebugInfo($this)
-            ->write("\$asm89CacheStrategy".$i." = \$this->env->getExtension('asm89_cache')->getCacheStrategy();\n")
+            ->write("\$asm89CacheStrategy".$i." = \$this->env->getExtension('".Extension::class."')->getCacheStrategy();\n")
             ->write("\$asm89Key".$i." = \$asm89CacheStrategy".$i."->generateKey(")
                 ->subcompile($this->getNode('annotation'))
                 ->raw(", ")


### PR DESCRIPTION
…s name (defined by getName()) is deprecated since 1.26 and will be removed in Twig 2.0. Use the Fully Qualified Extension Class Name instead.