### PR TITLE
allow twig v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php":       ">=5.3.2",
-        "twig/twig": "~1.0"
+        "twig/twig": "~1.0|~2.0"
     },
     "require-dev": {
         "doctrine/cache": "~1.0"


### PR DESCRIPTION
https://github.com/asm89/twig-cache-extension/issues/43 since https://github.com/asm89/twig-cache-extension/pull/30 is merged. It looks like a missing composer statement.