### PR TITLE
Fixed bug: Invalid recognition of extension name on Twig >= 1.26

### DIFF
--- a/lib/Asm89/Twig/CacheExtension/Extension.php
+++ b/lib/Asm89/Twig/CacheExtension/Extension.php
@@ -42,7 +42,7 @@ class Extension extends \Twig_Extension
     public function getName()
     {
         if (version_compare(\Twig_Environment::VERSION, '1.26.0', '>=')) {
-            return get_class($this);
+            return __CLASS__;
         }
         return 'asm89_cache';
     }


### PR DESCRIPTION
The "Asm89\Twig\CacheExtension\Extension" extension is not enabled.

I just did a `composer update` and spent a lot of time on figuring out why the application is not working.
Then next day in the morning I just got an idea and it worked. Here is the patch.

The problem occurs when I'm using the `emanueleminotto/twig-cache-bundle`, it has a class that extends this one, and then probably the child class is registered as service.