### PR TITLE
Add namespace prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     },
     "autoload": {
         "psr-4": {
-            "": "lib/"
+            "Asm89\\Twig\\": "lib/Asm89/Twig/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "": "test/"
+            "Asm89\\Twig\\CacheExtension\\Tests\\": "test/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Asm89\\Twig\\CacheExtension\\Tests\\": "test/"
+            "Asm89\\": "test/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Asm89\\Twig\\": "lib/Asm89/Twig/"
+            "Asm89\\": "lib/Asm89/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Empty namespace cause troubles in some situtations and is not good for performance.

The PR adds the missing namespace prefixes.

More details: #52